### PR TITLE
feat: integrate federated learning API proxy blueprint

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -14,6 +14,7 @@ from src.data.routes import routes as data_routes
 from src.privacy.routes import routes as privacy_routes
 from src.main.routes import routes as main_routes
 from src.visualization.routes import routes as visualization_routes
+from src.federated.routes import routes as federated_routes
 
 from backend.config import load_settings
 
@@ -36,6 +37,7 @@ def create_app(db_name=None):
     app.register_blueprint(data_routes, url_prefix="/data")
     app.register_blueprint(privacy_routes, url_prefix="/privacy")
     app.register_blueprint(visualization_routes, url_prefix="/visualization")
+    app.register_blueprint(federated_routes, url_prefix="/federated")
 
     if app.config["ENV"] == "development":
         CORS(app, origins="http://localhost:5000", supports_credentials=True)

--- a/backend/src/federated/__init__.py
+++ b/backend/src/federated/__init__.py
@@ -1,0 +1,1 @@
+from .routes import routes  # noqa: F401

--- a/backend/src/federated/routes.py
+++ b/backend/src/federated/routes.py
@@ -1,0 +1,91 @@
+import os
+
+import requests
+from flask import Blueprint, jsonify, render_template, request, session
+
+from src.auth.decorators import login_required
+
+routes = Blueprint("federated_routes", __name__)
+
+FED_API_BASE = os.environ.get("FED_API_BASE", "http://localhost:7070")
+
+
+def _forward(method, path, *, params=None, json_body=None):
+    """Forward a request to the FedDeepInsight service and proxy the response."""
+    headers = {}
+    auth = request.headers.get("Authorization")
+    if auth:
+        headers["Authorization"] = auth
+
+    url = f"{FED_API_BASE}{path}"
+    try:
+        resp = requests.request(
+            method,
+            url,
+            params=params,
+            json=json_body,
+            headers=headers,
+            timeout=10,
+        )
+    except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
+        return jsonify({"error": "Federated learning service unavailable"}), 503
+
+    try:
+        data = resp.json()
+    except ValueError:
+        data = {"raw": resp.text}
+
+    return jsonify(data), resp.status_code
+
+
+@routes.route("/register", methods=["POST"])
+def register():
+    payload = request.get_json(silent=True) or {}
+    return _forward("POST", "/federated/register", json_body=payload)
+
+
+@routes.route("/model", methods=["GET"])
+def model():
+    model_id = request.args.get("model_id")
+    if not model_id:
+        return jsonify({"error": "model_id is required"}), 400
+
+    params = {"model_id": model_id}
+    round_number = request.args.get("round")
+    if round_number is not None:
+        params["round"] = round_number
+    return _forward("GET", "/federated/model", params=params)
+
+
+@routes.route("/update", methods=["POST"])
+def update():
+    payload = request.get_json(silent=True) or {}
+    return _forward("POST", "/federated/update", json_body=payload)
+
+
+@routes.route("/aggregate", methods=["POST"])
+def aggregate():
+    payload = request.get_json(silent=True) or {}
+    return _forward("POST", "/federated/aggregate", json_body=payload)
+
+
+@routes.route("/state", methods=["GET"])
+def state():
+    model_id = request.args.get("model_id")
+    if not model_id:
+        return jsonify({"error": "model_id is required"}), 400
+    return _forward("GET", "/federated/state", params={"model_id": model_id})
+
+
+@routes.route("/ui", methods=["GET"])
+@login_required()
+def federated_ui():
+    return (
+        render_template(
+            "federated_learning/federated_learning.html",
+            model_id="federated-learning",
+            user_email=session.get("email"),
+            current_path=request.path,
+        ),
+        200,
+    )

--- a/backend/tests/federated/test_federated_routes.py
+++ b/backend/tests/federated/test_federated_routes.py
@@ -1,0 +1,121 @@
+"""Tests for the /federated blueprint.
+
+All upstream HTTP calls are mocked — no live FedDeepInsight service required.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests as req_lib
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _mock_response(status_code=200, json_data=None):
+    """Build a mock requests.Response."""
+    mock = MagicMock()
+    mock.status_code = status_code
+    mock.json.return_value = json_data or {}
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestFederatedInputValidation:
+    """Routes that validate required query params before hitting upstream."""
+
+    def test_state_missing_model_id(self, client):
+        resp = client.get("/federated/state")
+        assert resp.status_code == 400
+        assert b"model_id" in resp.data
+
+    def test_model_missing_model_id(self, client):
+        resp = client.get("/federated/model")
+        assert resp.status_code == 400
+        assert b"model_id" in resp.data
+
+
+class TestFederatedUnauthenticated:
+    """UI route requires login."""
+
+    def test_ui_redirects_when_not_logged_in(self, client):
+        resp = client.get("/federated/ui")
+        assert resp.status_code == 302
+
+
+class TestFederatedProxying:
+    """Routes that forward to the FedDeepInsight service."""
+
+    @patch("requests.request")
+    def test_register_forwards_payload(self, mock_req, client):
+        mock_req.return_value = _mock_response(200, {"status": "registered"})
+        resp = client.post(
+            "/federated/register",
+            json={"client_id": "c1"},
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["status"] == "registered"
+        mock_req.assert_called_once()
+
+    @patch("requests.request")
+    def test_update_forwards_payload(self, mock_req, client):
+        mock_req.return_value = _mock_response(200, {"ack": True})
+        resp = client.post(
+            "/federated/update",
+            json={"model_id": "m1", "round": 1, "weights": []},
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["ack"] is True
+
+    @patch("requests.request")
+    def test_aggregate_forwards_payload(self, mock_req, client):
+        mock_req.return_value = _mock_response(200, {"aggregated": True})
+        resp = client.post(
+            "/federated/aggregate",
+            json={"model_id": "m1", "round": 1},
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+
+    @patch("requests.request")
+    def test_state_forwards_with_model_id(self, mock_req, client):
+        mock_req.return_value = _mock_response(
+            200,
+            {"model_id": "m1", "round": 0, "status": "idle", "participating_clients": 0},
+        )
+        resp = client.get("/federated/state?model_id=m1")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["model_id"] == "m1"
+
+    @patch("requests.request")
+    def test_model_forwards_with_model_id(self, mock_req, client):
+        mock_req.return_value = _mock_response(
+            200, {"model_id": "m1", "round": 0, "weights": [0.1]}
+        )
+        resp = client.get("/federated/model?model_id=m1")
+        assert resp.status_code == 200
+        assert resp.get_json()["weights"] == [0.1]
+
+
+class TestFederatedUpstreamErrors:
+    """Upstream connectivity failures return 503."""
+
+    @patch("requests.request")
+    def test_connection_error_returns_503(self, mock_req, client):
+        mock_req.side_effect = req_lib.exceptions.ConnectionError
+        resp = client.get("/federated/state?model_id=m1")
+        assert resp.status_code == 503
+        assert b"unavailable" in resp.data
+
+    @patch("requests.request")
+    def test_timeout_returns_503(self, mock_req, client):
+        mock_req.side_effect = req_lib.exceptions.Timeout
+        resp = client.get("/federated/model?model_id=m1")
+        assert resp.status_code == 503
+        assert b"unavailable" in resp.data

--- a/frontend/templates/federated_learning/federated_learning.html
+++ b/frontend/templates/federated_learning/federated_learning.html
@@ -2,13 +2,37 @@
 {% block title %}FAIRMicrobiome | Federated Learning{% endblock %}
 {% block content %}
 <div class="row justify-content-center">
-   <br>
-   <h1>Federated learning
-   </h1>
-   
-
-
-
+   <div class="col-md-10">
+      <div class="card">
+         <div class="card-body">
+            <h1 class="display-6">Federated learning status</h1>
+            <p id="fed-status" class="mb-2">Loading...</p>
+            <pre id="fed-json" class="bg-light p-3 small"></pre>
+         </div>
+      </div>
+   </div>
 </div>
+
+<script>
+   const modelId = "{{ model_id }}";
+   const statusEl = document.getElementById("fed-status");
+   const jsonEl = document.getElementById("fed-json");
+
+   fetch(`/federated/state?model_id=${encodeURIComponent(modelId)}`)
+      .then((resp) => resp.json().then((data) => ({ ok: resp.ok, data })))
+      .then(({ ok, data }) => {
+         if (!ok || data.error) {
+            statusEl.textContent = data.error || "Failed to load state";
+            jsonEl.textContent = "";
+            return;
+         }
+         statusEl.textContent = `model_id=${data.model_id}, round=${data.round}, status=${data.status}, clients=${data.participating_clients}`;
+         jsonEl.textContent = JSON.stringify(data, null, 2);
+      })
+      .catch(() => {
+         statusEl.textContent = "Failed to load state";
+         jsonEl.textContent = "";
+      });
+</script>
 
 {% endblock %}


### PR DESCRIPTION
Adds /federated blueprint that proxies five FedDeepInsight endpoints (register, model, update, aggregate, state) plus a login-protected UI route at /federated/ui. FED_API_BASE is configurable via env var (defaults to http://localhost:7070). Connection errors and timeouts return 503 instead of crashing. Includes 10 pytest tests (all mocked, no live service required).